### PR TITLE
Documentation and error checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,3 +120,27 @@ release_date | version_number:
         - Refactored global variables into individual functions for reusability (i.e. generating or resetting)
             + Script should be cleaner
 
+- 2023-01-25 1435H | v1.3.0-rc1
+    - Compilation of all changes and releases
+    ```
+    [New Features]
+    - Command Line Arguments (CLI) support in install script
+        + -c | --config : For setting custom configuration file
+        + -d | --target-disk : For setting target disk name via CLI argument
+        + -g | --generate-config : For generating a new config file template right from the get-go
+        + -h | --help : Display help message
+        + -m | --mode : Set startup mode; DEBUG or RELEASE
+    - display_help() function to display a help menu
+
+    [Refactor/Modification]
+    - Changed 'MODE' variable from  to a static DEBUG as the command line argument is now dynamic
+    - Refactored global variables into individual functions for reusability (i.e. generating or resetting)
+        + Script should also be cleaner, improving readability 
+    - Changed documentation for 'distinstall' and README to reflect the latest usage
+    - Removed documentation from distinstall script as the help function explains it
+
+    [Errors/Bug Fixes]
+    - Error validation and checking, implementing exit if error was detected
+    ```
+
+

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ Linux Distribution Portable, Modular CLI/Terminal Base-Installation + Essential 
 ## Table of Contents
 
 - [Information](#information)
+- [Setup](#setup)
+- [Documentation](#documentation)
+- [Wiki](#wiki)
 - [FAQs](#faqs)
 - [Remarks](#remarks)
 - [Contacts](#contacts)
@@ -36,15 +39,16 @@ and/or the tools required by the target distribution changed, thus, leading to t
     + Thus, with the modular, containerized method, the modification of codes will be easier and customizable
 
  ### Files and Folders
-- [base-installation/](src/base-installation) : This is the Base Installation script. All files placed here have been tested from those found in dev (Development Folder). This is probably where you want to go first.
-- [post-installation/](src/post-installation) : This is the Post-Installation related scripts. All files placed here have been tested from those found in dev
+- [Source codes](src) : This is the root working directory containing the source files, configuration and scripts
+    - [base-installation/](src/base-installation) : This is the Base Installation script. All files placed here have been tested from those found in dev (Development Folder). This is probably where you want to go first.
+    - [post-installation/](src/post-installation) : This is the Post-Installation related scripts. All files placed here have been tested from those found in dev
 - [references/](references) : This references directory contains various useful files such as Sample configurations, Sample templates and Sample usage scripts.
 - [development](dev) : This is the development directory. This directory is essentially the Nightly Build branch and to be considered as Testing or unsafe, just to be safe, please test the files found here in a Virtual Machine.
 - [documentations](docs) : This contains all documentations and guides for references
     + including detailed setup; usage
     
 ## Setup
-> This is a basic rundown of how to use the program, please refer to [Base Installation Manual](docs/base-installation/manuals/distinstall/manual.md) for a more detailed rundown
+> This is a basic rundown of how to use the program, please refer to [Base Installation Manual](docs/manuals/distinstall.md) for a more detailed rundown
 ### Pre-Requisites
 + (Optional) Internet Connection
     ```
@@ -66,71 +70,156 @@ and/or the tools required by the target distribution changed, thus, leading to t
     curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/src/base-installation/distinstall"
     ```
 
-- Downloading the latest release
-    ```console
-    wget "https://github.com/Thanatisia/distro-installscript-arch/releases/latest/distinstall-*.zip"
-    ```
-    
+- Change Permission for use (Execute [x] and User [u])
+	```console
+	chmod u+x distinstall
+	```
+
 ### Obtaining Config File
-- via Autogeneration (Default)
-    - The application will check if a a config file exists (Default config file name is 'config.sh')
-        - If config file doesnt exist
-            + Application will automatically generate a 'config.sh' file on startup
-      
-- (OPTIONAL) Specifying a specific config file
-    - If you have a config file of a specific name
-        + Edit the variable "cfg_name" in *distinstall* with your custom config file name (TODO: Flag to specify custom config file)
-   
+- Default config file
+    + Default config file name : config.sh
+    + WIP/TODO: check if a a config file exists (Default config file name is 'config.sh')
+    ```console
+    ./distinstall -g
+    ```
+
+- Generate custom config file
+    + WIP/TODO: check if a a config file exists (Default config file name is 'config.sh')
+    ```console
+    ./distinstall -c [new-config-file-name]
+    ```
+
 - (OPTIONAL) Curling the example config.sh
     ```console
     curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/docs/configs/config.sh"
     ```
-   
+
+- Edit config file
+    ```console
+    $EDITOR [config file name]
+    ```
+
 ### Obtaining additional helper utilities/files
-- (OPTIONAL) Obtaining Makefile
-    + I designed this Makefile to automate and make running the installer easier
+- Makefile
+    - (OPTIONAL) Obtaining Makefile
+        + I designed this Makefile to automate and make running the installer easier
+        ```console
+        curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/docs/configs/Makefile"
+        ```
+
+    - (OPTIONAL) Editing the Makefile
+        + If you have obtained the Makefile and will be using this to install
+        + Edit the Makefile and specify your device labels and information
+            ```console
+            $EDITOR Makefile
+            ```
+
+### Obtaining all necessary files
+> Includes the above - Installer, config file and additional utilities
+- Downloading the latest release
     ```console
-    curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/docs/configs/Makefile"
+    wget "https://github.com/Thanatisia/distro-installscript-arch/releases/latest/distinstall-*.zip"
     ```
 
-   
 ## Documentation
+### Synopsis/Syntax
+```console
+./distinstall {options} [positional] <arguments>
+```
+
+### Parameters
+- Optional Parameters
+    - With Arguments
+        + -c [config-file-name] | --config      [config-file-name] : Set custom configuration file name
+        + -d [target-disk-name] | --target-disk [target-disk-name] : Set target disk name
+        + -m [DEBUG|RELEASE]    | --mode        [DEBUG|RELEASE]    : Set mode (DEBUG|RELEASE)
+    - Flags
+        + -g | --generate-config    : Generate configuration file
+        + -h | --help               : Display this help menu and all commands/command line arguments
+
+- Positional Parameters
+    + start : Start the installer
+
 ### Usage
-- Modify configuration file variables
-    + Default configuration file name: 'config.sh'
+- Examples
+    1. Default (Test Install; Did not specify target disk name explicitly)
         ```console
-        $EDITOR config.sh
+        ./distinstall start
         ```
 
-- (OPTIONAL) Editing the Makefile
-    + If you have obtained the Makefile and will be using this to install
-    + Edit the Makefile and specify your device labels and information
+    2. Test Install; with target disk name specified as flag
         ```console
-        $EDITOR Makefile
+        ./distinstall -d "/dev/sdX" start
         ```
-        
-- Execute installer (Default)
-    + At the moment, the script is called 'distinstall'
-    + By default: the script will execute in DEBUG mode whereby it shows you all the commands but it wont execute the formatting (security purposes)
-    ```console
-    TARGET_DISK_NAME='/dev/sdX' (./)distinstall {RERLEASE}
-    ```
+
+    3. Test Install; with target disk name specified with environment variable TARGET_DISK_NAME
+        ```console
+        TARGET_DISK_NAME="/dev/sdX" ./distinstall start
+        ```
+
+    4. Test Install; with custom configuration file
+        ```console
+        ./distinstall -c "new config file" -d "/dev/sdX" start
+        ```
+
+    5. Start installation (Did not specify target disk name explicitly)
+        ```console
+        sudo ./distinstall -m RELEASE start
+        ```
+
+    6. Start installation (with target disk name specified as flag)
+        ```console
+        sudo ./distinstall -d "/dev/sdX" -m RELEASE start
+        ```
+
+    7. Start installation (with target disk name specified with environment variable TARGET_DISK_NAME)
+        ```console
+        sudo TARGET_DISK_NAME="/dev/sdX" ./distinstall -m RELEASE start
+        ```
+
+    8. Start installation (with custom configuration file)
+        ```console
+        sudo ./distinstall -c "new config file" -d "/dev/sdX" -m RELEASE start
+        ```
+
+    9. Test Install; using Makefile
+        ```console
+        make testinstall
+        ```
+
+    10. Start installation; using Makefile
+        ```console
+        sudo make install
+        ```
+
+    11. Dis/Unmount using Makefile
+        ```console
+        sudo make clean
+        ```
+
+## Wiki
+- Modes
+    + DEBUG (Default) : Test install; Allows you to see all the commands that will be executed if you set the MODE to 'RELEASE'; set by default to prevent accidental reinstallation/overwriting
+    + RELEASE : Performs the real RELEASE; must use with sudo
+
+- Environment Variables
+	+ TARGET_DISK_NAME : This is used in the environment variable to specify the target disk you want to install with
+
+- Configuration guide
+    + Please refer to the [configuration guide](docs/installer%20configuration.md) for full information with regards to editing the configuration file
 
 ## FAQs
 
 ## Remarks
-```
 - Please do contact me in any of the platforms below if you have any ideas | bugs | comments | suggestions or if you just wanna talk!
-I am open for suggestions as well as talking to everyone
+    + I am open for suggestions as well as talking to everyone
 
 - Immediate Newsletter
 	- 2022-03-04 1349H | The current status of the scripts is tested primarily for brand new installations
 		+ I am attempting to and in the midst of adding pre-existing installation features as well as testings surrounding pre-existing distributions
 		+ Thus, please do becareful when attempting to multiboot with this script
-
 	- 2022-03-05 1147H | The script only has support for MBR (MSDOS/BIOS) Bootloader
 		+ Implementation of UEFI (EFI) support is currently in the plans
-        
     - 2022-06-20 1603H | Script has 2 types
         + This is a brief summary of the differences between type-1 and type-2, for more info, please check out the [Base Installation README.md](src/base-installation/README.md)
         - As of installer.remake.sh v1.0.5 and v1.0.8, I have created 2 types, known as [type-1] and [type-2]
@@ -139,7 +228,6 @@ I am open for suggestions as well as talking to everyone
             + type-2 is operating as a source-config environment, theres a template config generated inside the script itself though, you can also just curl/download th template i have in my docs directory that I will push to githube
         + I am still considering which format is more configurable, once I have decided, I will rework the project filestructure and tidy up the repository.
         + I apologise for the messy structure at the moment.
-
     - 2022-07-02 0019H | Stable release v1.0.0
         + First of all, thank you to everyone whom have provided feedback as to which type you prefer.
         - After careful consideration and testing, the application will follow a "seperate config" structure on top of the initial portable design paradigm
@@ -147,6 +235,14 @@ I am open for suggestions as well as talking to everyone
             + Thus, this makes the program more portable, configurable and customizable.
         + This means that this is what I would consider the first stable release
         + Other changes can be found in [Changelog](CHANGELOG.md)
+    - 2023-01-25 1311H | Implemented CLI Argument support and refactoring of documentations
+        - New Features
+            + Finally implemented CLI argument capabilities as well as writing it to be as easy to understand as possible, so as to make it customizable and modular
+        - Modifications
+            + Refactored installer to place initialized global variables into functions, allowing reusability, and readability as it is now cleaner
+        + Tested multiple times, should be stable (please create issues if any are found, thank you!)
+        + Please refer to the [CHANGELOGS](CHANGELOG.md) for all changes
+
 
 - I am thinking of making a discord group for my set of Linux Installation Script plans, do message me in any of the following contacts if you are interested.
 
@@ -155,7 +251,6 @@ I am open for suggestions as well as talking to everyone
 - Please star/follow this repository if you think this is useful!
 
 thank you again for using!
-```
 
 ## Contacts
 + [Twitter: @phantasu](https://twitter.com/phantasu)

--- a/TODO.md
+++ b/TODO.md
@@ -10,10 +10,10 @@
 - [] Add support for filesystems : 'btrfs'
 + [] Replace 'dev' folder with an official development branch
 - [] Complete creation of the additional installer GUI/CLI helper utility
-- [] Perform application overhaul
-    + [] Restructure project repository to become more coherent
+- [O] Perform application overhaul
+    + [O] Restructure project repository to become more coherent
 - [] Rename application from distinstall to something better
 - [O] Add command line (CLI) argument (parameters/flag) support
     + [O] To fit the mission
-- [] Refactor and rename variable 'devicePrams_Boot' in the configuration template structure as well as the installer
+- [X] Refactor and rename variable 'devicePrams_Boot' in the configuration template structure as well as the installer
 

--- a/docs/manuals/distinstall.md
+++ b/docs/manuals/distinstall.md
@@ -20,112 +20,189 @@ Documentations for Base Installation script [distinstall]
 	+ arch-install-scripts
 
 ### Obtaining
+- Installer
+    1. via cloning (Whole)
+        - This method will require you to download/clone the entire repository
 
-1. via cloning (Whole)
-	- This method will require you to download/clone the entire repository
+        + Syntax: git clone https://github.com/Thanatisia/distro-installscript-arch
 
-	+ Syntax: git clone https://github.com/Thanatisia/distro-installscript-arch
+    2. via cloning (Folder)
+        - This method will use the git 'sparse-checkout' to download a specific folder in the repository
+        - in this case : base-installation
+        - Syntax:
+            1. Initialize Local Git
+                ```console
+                git init
+                ```
+            2. Add path of remote repository
+                ```console
+                git remote add -f origin https://github.com/Thanatisia/distro-installscript-arch
+                ```
+            3. (OPTIONAL) Add config
+                ```console
+                git config user.name {username}
 
-2. via cloning (Folder)
-	- This method will use the git 'sparse-checkout' to download a specific folder in the repository
-	- in this case : base-installation
+                git config user.email {email}
+                ```
+            4. Initialize sparse-checkout git local repository folder
+                ```console
+                git sparse-checkout init
+                ```
+            5. Set path to tree
+                ```console
+                git sparse-checkout set "https://github.com/Thanatisia/distro-installscript-arch/tree/main/base-installation"
+                ```
+            6. Verify sparse-checkout
+                ```console
+                git sparse-checkout list
+                ```
+            7. Update new repository from sparse-checkout remote repository url
+                ```console
+                git pull origin {branch}
+                ```
 
-	- Syntax: 
-		1. Initialize Local Git
-			```console
-            git init
+    3. via curl
+        - This method allows you to download specifically the script to use
+        - Syntax: 
+            ```console
+            curl -L -O https://raw.githubusercontent.com/<author>/<repository_name>/<branch>/[folder/to/script_name.sh]
             ```
-            
-		2. Add path of remote repository
-			```console
-            git remote add -f origin https://github.com/Thanatisia/distro-installscript-arch
-            ```
-            
-		3. (OPTIONAL) Add config
-			```console
-            git config user.name {username}
+        - Examples:
+            - Development Branch (Deprecating soon in favour of the proper branch-PR method): https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/dev/src/distinstall
+            - Stable : https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/src/base-installation/distinstall
 
-			git config user.email {email}
-            ```
-            
-		4. Initialize sparse-checkout git local repository folder
-			```console
-            git sparse-checkout init
-            ```
-            
-		5. Set path to tree
-			```console
-            git sparse-checkout set "https://github.com/Thanatisia/distro-installscript-arch/tree/main/base-installation"
-            ```
-            
-		6. Verify sparse-checkout
-			```console
-            git sparse-checkout list
-            ```
-            
-		7. Update new repository from sparse-checkout remote repository url
-			```console
-            git pull origin {branch}
-            ```
-            
-3. via curl
+- Makefile
+    - (OPTIONAL) Obtaining Makefile
+        + I designed this Makefile to automate and make running the installer easier
+        ```console
+        curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/docs/configs/Makefile"
+        ```
 
-	- This method allows you to download specifically the script to use
+    - (OPTIONAL) Editing the Makefile
+        + If you have obtained the Makefile and will be using this to install
+        + Edit the Makefile and specify your device labels and information
+            ```console
+            $EDITOR Makefile
+            ```
 
-	- Syntax: 
-		```console
-		curl -L -O https://raw.githubusercontent.com/<author>/<repository_name>/<branch>/[folder/to/script_name.sh]
-		```
-
-	- Examples:
-        - Development Branch : https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/dev/src/distinstall
-        - Stable : https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/src/base-installation/distinstall
+- All necessary files
+    > Includes the above - Installer, config file and additional utilities
+    - Downloading the latest release
+        ```console
+        wget "https://github.com/Thanatisia/distro-installscript-arch/releases/latest/distinstall-*.zip"
+        ```
 
 ### Preparation/Setup
 
-- Initial Visit (No Config File)
-    - Download Default config file (config.sh)
+- Config File
+    - Default config file
+        + Default config file name : config.sh
+        + WIP/TODO: check if a a config file exists (Default config file name is 'config.sh')
+        ```console
+        ./distinstall -g
+        ```
+
+    - Generate custom config file
+        + WIP/TODO: check if a a config file exists (Default config file name is 'config.sh')
+        ```console
+        ./distinstall -c [new-config-file-name]
+        ```
+
+    - (OPTIONAL) Curling the example config.sh
         ```console
         curl -L -O "https://raw.githubusercontent.com/Thanatisia/distro-installscript-arch/main/docs/configs/config.sh"
         ```
-    - Generate default config file
-        + Just run the script
-        + The config will be generated
-      
-- Edit the config file
-    + Default Config File is config.sh
-        ```console
-        $EDITOR <your-config-file> 
-        ```
 
-- Modify file info according to your requirements
-    ```
-    NOTE: 
-    - You can just edit those labelled with "# EDIT: MODIFY THIS" if you do not know where to start
-    - Change the variables, you do not need to change the associative arrays but feel free to do so (only if you know what you are doing)
-        - In the case whereby you would like to edit the Associative Array, this is found in setup() for modularity
-    ```
+    - Edit config file
+        - NOTE: 
+            + You can just edit those labelled with "# EDIT: MODIFY THIS" if you do not know where to start
+            + Change the variables, you do not need to change the associative arrays but feel free to do so (only if you know what you are doing)
+            + In the case whereby you would like to edit the Associative Array, this is found in setup() for modularity
+        ```console
+        $EDITOR [config file name]
+        ```
 
 - (OPTIONAL) Backup the config file for re-usage
 
 ### Installation/Compilation
+> Currently installation is not required as it is using shellscript, however, there are plans on making a Rust-based/python installer for even easier configuration
 
 ## Documentations
 
 ### Synopsis/Syntax
+```console
+./distinstall {options} [positional] <arguments>
+```
 
-+ TARGET_DISK_NAME='your-disk-label (/dev/sdX)' (./)distinstall {MODE}
+### Parameters
+- Optional Parameters
+    - With Arguments
+        + -c [config-file-name] | --config      [config-file-name] : Set custom configuration file name
+        + -d [target-disk-name] | --target-disk [target-disk-name] : Set target disk name
+        + -m [DEBUG|RELEASE]    | --mode        [DEBUG|RELEASE]    : Set mode (DEBUG|RELEASE)
+    - Flags
+        + -g | --generate-config    : Generate configuration file
+        + -h | --help               : Display this help menu and all commands/command line arguments
 
-### Parameters/Options/Flags
+- Positional Parameters
+    + start : Start the installer
 
-- MODE <options> : The mode to run the program
-	+ Default: DEBUG
-		
-	- Options:
-		+ DEBUG	: Use this to run the program and see the commands being used 				(DEFAULT)
-		+ RELEASE : Use this to set the program to release and actually make changes to the system
-	
 ### Usage
+
+1. Default (Test Install; Did not specify target disk name explicitly)
+    ```console
+    ./distinstall start
+    ```
+
+2. Test Install; with target disk name specified as flag
+    ```console
+    ./distinstall -d "/dev/sdX" start
+    ```
+
+3. Test Install; with target disk name specified with environment variable TARGET_DISK_NAME
+    ```console
+    TARGET_DISK_NAME="/dev/sdX" ./distinstall start
+    ```
+
+4. Test Install; with custom configuration file
+    ```console
+    ./distinstall -c "new config file" -d "/dev/sdX" start
+    ```
+
+5. Start installation (Did not specify target disk name explicitly)
+    ```console
+    sudo ./distinstall -m RELEASE start
+    ```
+
+6. Start installation (with target disk name specified as flag)
+    ```console
+    sudo ./distinstall -d "/dev/sdX" -m RELEASE start
+    ```
+
+7. Start installation (with target disk name specified with environment variable TARGET_DISK_NAME)
+    ```console
+    sudo TARGET_DISK_NAME="/dev/sdX" ./distinstall -m RELEASE start
+    ```
+
+8. Start installation (with custom configuration file)
+    ```console
+    sudo ./distinstall -c "new config file" -d "/dev/sdX" -m RELEASE start
+    ```
+
+9. Test Install; using Makefile
+    ```console
+    make testinstall
+    ```
+
+10. Start installation; using Makefile
+    ```console
+    sudo make install
+    ```
+
+11. Dis/Unmount using Makefile
+    ```console
+    sudo make clean
+    ```
 
 1. Change Permission for use (Execute [+x])
 	```console
@@ -167,12 +244,19 @@ Documentations for Base Installation script [distinstall]
 
 ## Configuration and Customization
 
-#### Environment Variables
-+ TARGET_DISK_NAME : To set the disk/device label you wish to use (/dev/sdX)
+### Environment Variables
++ TARGET_DISK_NAME : This is used in the environment variable to specify the target disk you want to install with
 
-#### Modifiable Variables (in distinstall)
+### Modifiable Variables (in distinstall)
 - cfg_name : the default configuration file name, change this variable before executing to use a specific config file *AND/OR* generate a default file in this custom filename
     + Default Value : config.sh
+
+- Modes
+    + DEBUG (Default) : Test install; Allows you to see all the commands that will be executed if you set the MODE to 'RELEASE'; set by default to prevent accidental reinstallation/overwriting
+    + RELEASE : Performs the real RELEASE; must use with sudo
+
+### Configuration guide
++ Please refer to the [configuration guide](docs/installer%20configuration.md) for full information with regards to editing the configuration file
 
 ### To Note
 

--- a/src/base-installation/Makefile
+++ b/src/base-installation/Makefile
@@ -3,14 +3,14 @@
 # [Variables]
 
 # Settings and Configurations
-TARGET_DISK = /dev/sdd
+TARGET_DISK = /dev/sdX
 MOUNT_ROOT = "/mnt"
 MOUNT_PATHS = "/mnt/boot" "/mnt" "/mnt/home"
 
 # Program Variables
 ENV = TARGET_DISK_NAME="$(TARGET_DISK)"	# Environment Variables
-SCRIPT = "distinstall"					# Script Filename
-CFLAGS = "RELEASE"						# Compilation Flags
+SCRIPT = distinstall					# Script Filename
+CFLAGS =                                # Compilation Flags
 
 # [Commands]
 CMD = $(ENV) ./$(SCRIPT)
@@ -41,13 +41,14 @@ init:
 testinstall: init
 	## Run the install script testsuite
 	# - Run this with sudo for username verification
-	$(CMD)
+	$(CMD) $(CFLAGS) start
 
 install: clean
 	## Run the install script and install
 	# WARNING: This will overwrite the target disk/filesystem, please be careful
 	# - Run this with sudo
-	$(CMD) $(CFLAGS)
+	$(eval CFLAGS=-m "RELEASE")
+	$(CMD) $(CFLAGS) start
 
 genscript:
 	## Run install-gen and generate the commands to install and

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -1134,8 +1134,8 @@ installer()
     echo "(D) Network testing completed."
 
     if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1148,8 +1148,8 @@ installer()
     echo -e "(D) Boot Mode verification completed."
 
     if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1157,13 +1157,16 @@ installer()
 	echo "Stage 3: Update System Clock"
 	echo "============================"
     echo -e "(S) Updating System Clock..."
-    update_system_Clock && \ 
-        echo -e "(D) System clock updated." || \
-        echo -e "(X) Error updating system clock via Network Time Protocol (NTP)"; exit 1
+    update_system_Clock
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Error updating system clock via Network Time Protocol (NTP)"
+        exit 1
+    fi
+    echo -e "(D) System clock updated."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1171,13 +1174,16 @@ installer()
 	echo "Stage 4: Partition the Disks"
 	echo "============================"
     echo -e "(S) Starting Disk Management..."
-    device_partition_Manager && \
-        echo -e "(D) Disk Management completed." || \
-        echo -e "(X) Error formatting disk and partitions"; exit 1
+    device_partition_Manager
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Error formatting disk and partitions"
+        exit 1
+    fi
+    echo -e "(D) Disk Management completed."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1185,13 +1191,16 @@ installer()
 	echo "Stage 5: Mount Disks"
 	echo "===================="
     echo -e "(S) Mounting disks..."
-	mount_Disks && \
-        echo -e "(D) Disks mounted." || \
-        echo -e "(X) Error mounting disks"; exit 1
+    mount_Disks
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Error mounting disks"
+        exit 1
+    fi
+    echo -e "(D) Disks mounted."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1202,9 +1211,9 @@ installer()
 	echo $EDITOR /etc/pacman.d/mirrorlist
     echo -e "(D) Mirror selected."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1212,13 +1221,16 @@ installer()
 	echo "Stage 7: Install essential packages"
 	echo "==================================="
     echo -e "(S) Strapping packages to mount point..."
-	pacstrap_Install && \
-        echo -e "(D) Packages strapped." || \
-        echo -e "(X) Errors bootstrapping packages"; exit 1
+    pacstrap_Install
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Errors bootstrapping packages"
+        exit 1
+    fi
+    echo -e "(D) Packages strapped."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1226,13 +1238,16 @@ installer()
 	echo "Stage 8: Generate fstab (File System Table)"
 	echo "==========================================="
     echo -e "(S) Generating Filesystems Table in /etc/fstab"
-	fstab_Generate && \
-        echo -e "(D) Filesystems Table generated." || \
-        echo -e "(X) Error generating filesystems table"; exit 1
+    fstab_Generate
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Error generating filesystems table"
+        exit 1
+    fi
+    echo -e "(D) Filesystems Table generated."
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1240,13 +1255,16 @@ installer()
 	echo "Stage 9: Chroot and execute"
 	echo "==========================="
     echo -e "(S) Executing chroot commands"
-	arch_chroot_Exec && \ # Execute commands in arch-chroot
-        echo -e "(D) Commands executed" || \
-        echo -e "(X) Error executing commands in chroot"; exit 1
+    arch_chroot_Exec # Execute commands in arch-chroot
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(X) Error executing commands in chroot"
+        exit 1
+    fi
+    echo -e "(D) Commands executed"
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1262,13 +1280,16 @@ installer()
     echo -e "(S) Starting Basic Post-Installation"
 
     echo -e "(+) Running post-installation..."
-	postinstallation && \
-        echo -e "(+) Post-Installation execution completed" || \
-        echo -e "(-) Error detected in post-installation process"; exit 1
+    postinstallation
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(-) Error detected in post-installation process"
+        exit 1
+    fi
+    echo -e "(+) Post-Installation execution completed"
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 
@@ -1276,13 +1297,16 @@ installer()
 	echo "Sanitization and Cleanup"
 	echo "========================"
     echo -e "(+) Running finalization and sanitization..."
-	postinstall_sanitize && \
-        echo -e "(+) Sanitization completed" || \
-        echo -e "(-) Error detected in post-installation sanitization and cleanup"; exit 1
+    postinstall_sanitize
+    if [[ "$?" -gt 0 ]]; then
+        echo -e "(-) Error detected in post-installation sanitization and cleanup"
+        exit 1
+    fi
+    echo -e "(+) Sanitization completed"
 
-	if [[ "$MODE" == "DEBUG" ]]; then
-		read -p "Press anything to continue..." tmp
-	fi
+    if [[ "$MODE" == "DEBUG" ]]; then
+        read -p "Press anything to continue..." tmp
+    fi
 
 	echo ""
 

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -89,16 +89,21 @@ Script Name : $PROGRAM_SCRIPTNAME
 Program Name : $PROGRAM_NAME
 Program Version : $PROGRAM_VERSION
 
-Command Line (CLI) Arguments:
-	- Optional Parameters
-		+ -c | --config             : Set custom configuration file name
-		+ -d | --target-disk        : Set target disk name
-		+ -g | --generate-config    : Generate configuration file
-		+ -m | --mode               : Set mode (DEBUG|RELEASE)
-		+ -h | --help               : Display this help menu and all commands/command line arguments
+Synopsis/Syntax:
+    $0 {options} [positional] <arguments>
 
-	- Positional Parameters
-		+ start : Start the installer
+Command Line (CLI) Arguments:
+    - Optional Parameters
+        - With Arguments
+            + -c [config-file-name] | --config      [config-file-name] : Set custom configuration file name
+            + -d [target-disk-name] | --target-disk [target-disk-name] : Set target disk name
+            + -m [DEBUG|RELEASE]    | --mode        [MODE|RELEASE]     : Set mode (DEBUG|RELEASE)
+        - Flags
+            + -g | --generate-config    : Generate configuration file
+            + -h | --help               : Display this help menu and all commands/command line arguments
+
+    - Positional Parameters
+        + start : Start the installer
 
 Modes:
 	+ DEBUG (Default) : Test install; Allows you to see all the commands that will be executed if you set the MODE to 'RELEASE'; set by default to prevent accidental reinstallation/overwriting
@@ -106,6 +111,31 @@ Modes:
 
 Environment Variables:
 	+ TARGET_DISK_NAME : This is used in the environment variable to specify the target disk you want to install with
+
+Examples:
+    1. Default (Test Install; Did not specify target disk name explicitly)
+        $0 start
+
+    2. Test Install; with target disk name specified as flag
+        $0 -d "/dev/sdX" start
+
+    3. Test Install; with target disk name specified with environment variable TARGET_DISK_NAME
+        TARGET_DISK_NAME="/dev/sdX" $0 start
+
+    4. Start installation (Did not specify target disk name explicitly)
+        sudo $0 -m RELEASE start
+
+    5. Start installation (with target disk name specified as flag)
+        sudo $0 -d "/dev/sdX" -m RELEASE start
+
+    6. Start installation (with target disk name specified with environment variable TARGET_DISK_NAME)
+        sudo TARGET_DISK_NAME="/dev/sdX" $0 -m RELEASE start
+
+    7. Test Install; using Makefile
+        make testinstall
+
+    8. Start installation; using Makefile
+        sudo make install
 EOF
 	)
     echo -e "$help_msg"
@@ -1127,8 +1157,9 @@ installer()
 	echo "Stage 3: Update System Clock"
 	echo "============================"
     echo -e "(S) Updating System Clock..."
-    update_system_Clock
-    echo -e "(D) System clock updated."
+    update_system_Clock && \ 
+        echo -e "(D) System clock updated." || \
+        echo -e "(X) Error updating system clock via Network Time Protocol (NTP)"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1140,8 +1171,9 @@ installer()
 	echo "Stage 4: Partition the Disks"
 	echo "============================"
     echo -e "(S) Starting Disk Management..."
-    device_partition_Manager
-    echo -e "(D) Disk Management completed."
+    device_partition_Manager && \
+        echo -e "(D) Disk Management completed." || \
+        echo -e "(X) Error formatting disk and partitions"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1153,8 +1185,9 @@ installer()
 	echo "Stage 5: Mount Disks"
 	echo "===================="
     echo -e "(S) Mounting disks..."
-	mount_Disks
-    echo -e "(D) Disks mounted."
+	mount_Disks && \
+        echo -e "(D) Disks mounted." || \
+        echo -e "(X) Error mounting disks"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1179,8 +1212,9 @@ installer()
 	echo "Stage 7: Install essential packages"
 	echo "==================================="
     echo -e "(S) Strapping packages to mount point..."
-	pacstrap_Install
-    echo -e "(D) Packages strapped."
+	pacstrap_Install && \
+        echo -e "(D) Packages strapped." || \
+        echo -e "(X) Errors bootstrapping packages"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1192,8 +1226,9 @@ installer()
 	echo "Stage 8: Generate fstab (File System Table)"
 	echo "==========================================="
     echo -e "(S) Generating Filesystems Table in /etc/fstab"
-	fstab_Generate
-    echo -e "(D) Filesystems Table generated."
+	fstab_Generate && \
+        echo -e "(D) Filesystems Table generated." || \
+        echo -e "(X) Error generating filesystems table"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1205,8 +1240,9 @@ installer()
 	echo "Stage 9: Chroot and execute"
 	echo "==========================="
     echo -e "(S) Executing chroot commands"
-	arch_chroot_Exec # Execute commands in arch-chroot
-    echo -e "(D) Commands executed"
+	arch_chroot_Exec && \ # Execute commands in arch-chroot
+        echo -e "(D) Commands executed" || \
+        echo -e "(X) Error executing commands in chroot"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1226,8 +1262,9 @@ installer()
     echo -e "(S) Starting Basic Post-Installation"
 
     echo -e "(+) Running post-installation..."
-	postinstallation
-    echo -e "(+) Post-Installation execution completed"
+	postinstallation && \
+        echo -e "(+) Post-Installation execution completed" || \
+        echo -e "(-) Error detected in post-installation process"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp
@@ -1239,8 +1276,9 @@ installer()
 	echo "Sanitization and Cleanup"
 	echo "========================"
     echo -e "(+) Running finalization and sanitization..."
-	postinstall_sanitize
-    echo -e "(+) Sanitization completed"
+	postinstall_sanitize && \
+        echo -e "(+) Sanitization completed" || \
+        echo -e "(-) Error detected in post-installation sanitization and cleanup"; exit 1
 
 	if [[ "$MODE" == "DEBUG" ]]; then
 		read -p "Press anything to continue..." tmp

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -48,8 +48,8 @@ Modular, Portable, Customizable and Configurable script that can be modified int
 
 ### Usage
 
-+ TARGET_DISK_NAME='/dev/sdX' (./)distinstall           : Run in DEBUG mode
-+ TARGET_DISK_NAME='/dev/sdX' (./)distinstall RELEASE   : Run installation
++ TARGET_DISK_NAME='/dev/sdX' (./)distinstall              : Run in DEBUG mode
++ TARGET_DISK_NAME='/dev/sdX' (./)distinstall -m RELEASE   : Run installation
 
 ## Configuration and Customization
     ## Environment Variables
@@ -66,7 +66,7 @@ References:
 PROGRAM_SCRIPTNAME="installer"
 PROGRAM_NAME="ArchLinux Profile Setup Installer"
 PROGRAM_TYPE="Main"
-PROGRAM_VERSION="v1.1.8-testing"
+PROGRAM_VERSION="v1.2.2-testing"
 MODE="DEBUG" # { DEBUG | RELEASE }
 DISTRO="ArchLinux"
 cfg_name="config.sh"
@@ -1509,6 +1509,9 @@ init()
 
         device_Parameters["device_Name"]=$deviceParams_Name
     fi
+
+    echo -e ""
+
     echo -e "(D) Initialization completed"
 }
 
@@ -1568,6 +1571,9 @@ body()
                 "start")
                     # Start the installer
                     init # Initialize and perform pre-processing and pre-startup checks
+
+                    echo -e ""
+
 	                installer # Start installer
 
                     # Check the function outcome
@@ -1585,6 +1591,7 @@ body()
                     # Invalid arguments provided
                     echo -e "Invalid parameter : $i"
                     shift 1
+                    exit 1
                     ;;
             esac
         done

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -32,29 +32,6 @@ Modular, Portable, Customizable and Configurable script that can be modified int
         + Testing using ArchISO completed, status : Success
         + Testing using Existing Linux Distribution (Base Arch) completed, status: Success
 
-## Documentation
-
-### Synopsis/Syntax
-
-+ TARGET_DISK_NAME='your-disk-label (/dev/sdX)' (./)distinstall {MODE}
-
-### Parameters
-
-- Positional Arguments
-    1. MODE
-        - Options
-            + DEBUG     : Display only the commands
-            + RELEASE   : Run the installation
-
-### Usage
-
-+ TARGET_DISK_NAME='/dev/sdX' (./)distinstall              : Run in DEBUG mode
-+ TARGET_DISK_NAME='/dev/sdX' (./)distinstall -m RELEASE   : Run installation
-
-## Configuration and Customization
-    ## Environment Variables
-    + TARGET_DISK_NAME : To set the disk/device label you wish to use (/dev/sdX)
-
 References:
     1. Multiline-scripting in Arch-chroot : https://www.reddit.com/r/archlinux/comments/bssbze/scripting_into_chroot/
 =====================================
@@ -66,7 +43,7 @@ References:
 PROGRAM_SCRIPTNAME="installer"
 PROGRAM_NAME="ArchLinux Profile Setup Installer"
 PROGRAM_TYPE="Main"
-PROGRAM_VERSION="v1.2.2-testing"
+PROGRAM_VERSION="v1.3.0"
 MODE="DEBUG" # { DEBUG | RELEASE }
 DISTRO="ArchLinux"
 cfg_name="config.sh"
@@ -1589,7 +1566,7 @@ body()
                     ;;
                 *)
                     # Invalid arguments provided
-                    echo -e "Invalid parameter : $i"
+                    echo -e "Invalid parameter : $1"
                     shift 1
                     exit 1
                     ;;


### PR DESCRIPTION
Update 2023-01-25 1402H | v1.3.0
- Release Candidate 1, tested before pushing to main branch via Pull Request
- Compilation of all changes and releases
    [New Features]
    - Command Line Arguments (CLI) support in install script
        + -c | --config : For setting custom configuration file
        + -d | --target-disk : For setting target disk name via CLI argument
        + -g | --generate-config : For generating a new config file template right from the get-go
        + -h | --help : Display help message
        + -m | --mode : Set startup mode; DEBUG or RELEASE
    - display_help() function to display a help menu

    [Refactor/Modification]
    - Changed 'MODE' variable from  to a static DEBUG as the command line argument is now dynamic
    - Refactored global variables into individual functions for reusability (i.e. generating or resetting)
        + Script should also be cleaner, improving readability 
    - Changed documentation for 'distinstall' and README to reflect the latest usage
    - Removed documentation from distinstall script as the help function explains it

    [Errors/Bug Fixes]
    - Error validation and checking, implementing exit if error was detected

