### PR TITLE
Merging v1.3.6

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,15 @@
+# ISSUES
+
+* Current Issues and Bugs encountered that needs to be solved
+
+## Bugs
+- distinstall
+	- mount_Disks()
+		- [] Mounting of directories to partitions - after removing the static root, boot and home partitions in favour of Dynamic partitions - are now inconsistent
+		   	+ Due to the mounting order being incorrect
+		   	- Issue : Unmounting via 'sudo make clean' will not unmount the test mounted partition '/mnt/home'
+				- Temporary Solution: Unmounting via 'umount -l /mnt' using the unit test case needs to be repeated twice; once with '/mnt' and another with '/mnt/home'
+			- Note
+			   - The mounting process itself still works and the system will still boot and mount properly, just that this seems to be an irritating issue that happens if the order of arrangement with regards to mounting the partitions in the following order respectively : 'root' partition => 'boot' and 'home'
+			+ Issue Opened: 2023-01-26 22:39H by Asura
+

--- a/TODO.md
+++ b/TODO.md
@@ -4,11 +4,13 @@
 - [List](#list)
 
 ## List
-+ [] UEFI Support
++ [] UEFI Motherboard firmware Support
++ [] GPT Partition Table and filesystem label support
 - Other Bootloader Support
     + [] syslinux
 - [] Add support for filesystems : 'btrfs'
 - [] Add support for Swap partitions
+- [] Add support for raw disk image file system installation into mounted loopback interface
 + [] Replace 'dev' folder with an official development branch
 - [] Complete creation of the additional installer GUI/CLI helper utility
 - [O] Perform application overhaul

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
 - Other Bootloader Support
     + [] syslinux
 - [] Add support for filesystems : 'btrfs'
+- [] Add support for Swap partitions
 + [] Replace 'dev' folder with an official development branch
 - [] Complete creation of the additional installer GUI/CLI helper utility
 - [O] Perform application overhaul

--- a/docs/configs/Makefile
+++ b/docs/configs/Makefile
@@ -10,7 +10,7 @@ MOUNT_PATHS = "/mnt/boot" "/mnt" "/mnt/home"
 # Program Variables
 ENV = TARGET_DISK_NAME="$(TARGET_DISK)"	# Environment Variables
 SCRIPT = "distinstall"					# Script Filename
-CFLAGS = "RELEASE"						# Compilation Flags
+CFLAGS =         						# Compilation Flags
 
 # [Commands]
 CMD = $(ENV) ./$(SCRIPT)
@@ -41,18 +41,20 @@ init:
 testinstall: init
 	## Run the install script testsuite
 	# - Run this with sudo for username verification
-	$(CMD)
+	$(CMD) $(CFLAGS) start
 
 install: clean
 	## Run the install script and install
 	# WARNING: This will overwrite the target disk/filesystem, please be careful
 	# - Run this with sudo
-	$(CMD) $(CFLAGS)
+	$(eval CFLAGS=-m "RELEASE")
+	$(CMD) $(CFLAGS) start
 
 genscript:
 	## Run install-gen and generate the commands to install and
 	# Output as a script file for backup
-	./install-gen
+	# Still in testing and development phase
+	@makes -s testinstall | tee -a commands.sh
 
 clean: 
 	## Clean all temporary files and unmount drives 

--- a/docs/configs/config.sh
+++ b/docs/configs/config.sh
@@ -1,4 +1,6 @@
-
+#==============================#
+# Distro Installer Config File #
+#==============================#
 : "
 Variables to be imported into the installer file
 
@@ -26,7 +28,7 @@ Variables to be imported into the installer file
 deviceParams_devType="<hdd|ssd|flashdrive|microSD>"
 deviceParams_Name="$TARGET_DISK_NAME"
 deviceParams_Size="<x {GB | GiB | MB | MiB}"
-devicePrams_Boot="<mbr|uefi>"
+deviceParams_Boot="<mbr|uefi>"
 deviceParams_Label="<msdos|gpt>"
 boot_Partition=(
 	# Append this and append a [n]="${boot_Partition[<n-1>]}" in
@@ -38,9 +40,20 @@ boot_Partition=(
 )
 mount_Paths=(
 	# Append this and append a [n]="${mount_Paths[<n-1>]}" in
-	"/mnt/boot"	# Boot
-	"/mnt"		# Root
-	"/mnt/home"	# Home
+	# This contains the mount paths mapped to the partition name
+	# Note:
+	#   - Please seperate all parameters with delimiter ','
+	#   - Please seperate all subvalues with delimiter ';'
+	#
+	# Syntax:
+	# [Partition Name],[mount path]
+	#
+	# Some Manadatory partition names:
+	#   - For Boot Partition : 'Boot'
+	#   - For Root Partition : 'Root'
+	"Boot,/mnt/boot"	# Boot
+	"Root,/mnt"			# Root
+	"Home,/mnt/home"	# Home
 )
 pacstrap_pkgs=(
 		# EDIT: MODIFY THIS

--- a/docs/installer configuration.md
+++ b/docs/installer configuration.md
@@ -131,21 +131,29 @@
 			```
 - mount_Paths : Specify all paths and directories you want to mount corresponding to the partition number specified in 'boot_Partition'
 	+ Data Type: ArrayList; List
+	- Notes
+		+ Please seperate all parameters with delimiter ','
+		+ Please seperate all subvalues with delimiter ';'
+	- Syntax/Synopsis
+		- Components
+			+ Partition Name : This is the name of the partition you wish to mount the corresponding mount path to; the partition name is the same as the one specified in 'boot_Partition'
+			+ Mount Path : This is the path to the mount filesystem/directory
 	- Structure
 		```shellscript
 		mount_Paths=(
 			# Add a seperate path/directory you want to mount corresponding to the partition number specified in 'boot_Partition'
-			"/directory/to/mount/filesystem/or/directory/path/1" # partition 1
-			"/directory/to/mount/filesystem/or/directory/path/2" # partition 2
-			"/directory/to/mount/filesystem/or/directory/path/3" # partition 3
+			# "[Partition Name],[Mount Path]"
+			"Partition Name,/directory/to/mount/filesystem/or/directory/path/1" # partition 1
+			"Partition Name,/directory/to/mount/filesystem/or/directory/path/2" # partition 2
+			"Partition Name,/directory/to/mount/filesystem/or/directory/path/3" # partition 3
 		)
 		```
 	- Examples
 		```shellscript
 		mount_Paths=(
-			"/mnt/boot"	# Boot
-			"/mnt"		# Root
-			"/mnt/home"	# Home
+			"Boot,/mnt/boot"	# Boot
+			"Root,/mnt"         # Root
+			"Home,/mnt/home"	# Home
 		)
 		```
 

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -74,7 +74,7 @@ Command Line (CLI) Arguments:
         - With Arguments
             + -c [config-file-name] | --config      [config-file-name] : Set custom configuration file name
             + -d [target-disk-name] | --target-disk [target-disk-name] : Set target disk name
-            + -m [DEBUG|RELEASE]    | --mode        [MODE|RELEASE]     : Set mode (DEBUG|RELEASE)
+            + -m [DEBUG|RELEASE]    | --mode        [DEBUG|RELEASE]    : Set mode (DEBUG|RELEASE)
         - Flags
             + -g | --generate-config    : Generate configuration file
             + -h | --help               : Display this help menu and all commands/command line arguments
@@ -99,20 +99,29 @@ Examples:
     3. Test Install; with target disk name specified with environment variable TARGET_DISK_NAME
         TARGET_DISK_NAME="/dev/sdX" $0 start
 
-    4. Start installation (Did not specify target disk name explicitly)
+    4. Test Install; with custom configuration file
+        $0 -c "new config file" -d "/dev/sdX" start
+
+    5. Start installation (Did not specify target disk name explicitly)
         sudo $0 -m RELEASE start
 
-    5. Start installation (with target disk name specified as flag)
+    6. Start installation (with target disk name specified as flag)
         sudo $0 -d "/dev/sdX" -m RELEASE start
 
-    6. Start installation (with target disk name specified with environment variable TARGET_DISK_NAME)
+    7. Start installation (with target disk name specified with environment variable TARGET_DISK_NAME)
         sudo TARGET_DISK_NAME="/dev/sdX" $0 -m RELEASE start
 
-    7. Test Install; using Makefile
+    8. Start installation (with custom configuration file)
+        sudo ./distinstall -c "new config file" -d "/dev/sdX" -m RELEASE start
+
+    9. Test Install; using Makefile
         make testinstall
 
-    8. Start installation; using Makefile
+    10. Start installation; using Makefile
         sudo make install
+
+    11. Dis/Unmount using Makefile
+        sudo make clean
 EOF
 	)
     echo -e "$help_msg"
@@ -1022,9 +1031,12 @@ postinstall_sanitize()
 						u_home_Dir="${curr_user_Params[3]}"             # Home Directory
 						u_other_Params="${curr_user_Params[@]:4}"       # Any other parameters after the first 3
 
-						echo "Copying from [$PWD] : curl_repositories.sh => /mnt/$u_home_Dir"
-						cp curl_repositories.sh /mnt/$u_home_Dir/curl_repositories.sh														# Copy script from root to user
-						arch-chroot $dir_Mount /bin/bash -c "chown -R $u_name:$u_primary_Group $u_home_Dir/curl_repositories.sh"		# Change ownership of file to user
+                        for ((i=0; i < $number_of_external_scripts; i++)); do
+                            curr_script="${external_scripts[$i]}"
+                            echo "Copying from [$dir_Mount] : $curr_script => /mnt/$u_home_Dir"
+                            cp $curr_script /mnt/$u_home_Dir/														# Copy script from root to user
+                            # arch-chroot $dir_Mount /bin/bash -c "chown -R $u_name:$u_primary_Group $u_home_Dir/$curr_script"		# Change ownership of file to user
+                        done
 					done
 					;;
 				"S" | "Select")
@@ -1032,9 +1044,14 @@ postinstall_sanitize()
 					read -p "User name: " sel_uhome
 					sel_primary_group=$(arch-chroot $dir_Mount /bin/bash -c "su - $sel_uhome -c 'echo \$(id -gn $sel_uhome)'")
 					sel_uhome_dir=$(arch-chroot $dir_Mount /bin/bash -c "su - $sel_uhome -c 'echo \$HOME'")
-					echo "Copying from [$PWD] : curl_repositories.sh => /mnt/$sel_uhome_dir/curl_repositories.sh"
-					cp curl_repositories.sh /mnt/$sel_uhome_dir/curl_repositories.sh
-					arch-chroot $dir_Mount /bin/bash -c "chown -R $sel_uhome:$sel_primary_group $sel_uhome_dir/curl_repositories.sh"		# Change ownership of file to user
+
+                    # Start copy
+                    for ((i=0; i < $number_of_external_scripts; i++)); do
+                        curr_script="${external_scripts[$i]}"
+                        echo "Copying from [$dir_Mount] : $curr_script => /mnt/$sel_uhome_dir/"
+                        cp $curr_script /mnt/$sel_uhome_dir/
+                        # arch-chroot $dir_Mount /bin/bash -c "chown -R $sel_uhome:$sel_primary_group $sel_uhome_dir/$curr_script"		# Change ownership of file to user
+                    done
 					;;
 				*)
 					;;

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -43,7 +43,7 @@ References:
 PROGRAM_SCRIPTNAME="installer"
 PROGRAM_NAME="ArchLinux Profile Setup Installer"
 PROGRAM_TYPE="Main"
-PROGRAM_VERSION="v1.3.0"
+PROGRAM_VERSION="v1.3.2-testing"
 MODE="DEBUG" # { DEBUG | RELEASE }
 DISTRO="ArchLinux"
 cfg_name="config.sh"
@@ -1335,10 +1335,14 @@ setup()
         # Please append according to your needs
         # [Syntax]
         # ROW_ID="<partition_ID>;<partition_Name>;<partition_file_Type>;<partition_start_Size>;<partition_end_Size>;<partition_Bootable>;<partition_Others>
-        [1]="${boot_Partition[0]}"
-        [2]="${boot_Partition[1]}"
-        [3]="${boot_Partition[2]}"
+        # [1]="${boot_Partition[0]}"
+        # [2]="${boot_Partition[1]}"
+        # [3]="${boot_Partition[2]}"
     )
+    for curr_partition_row in "${!boot_Partition[@]}"; do
+        curr_partition="${boot_Partition[$curr_partition_row]}"
+        partition_Configuration[$curr_mount_row]="$curr_partition"
+    done
 
     partition_Parameters=(
         # This is the default container for partition parameters
@@ -1362,10 +1366,14 @@ setup()
         #	corresponding to the partition number
         # [Syntax]
         #   [partition-n]="/partition/mount/path"
-        [1]="${mount_Paths[0]}"	# Boot
-        [2]="${mount_Paths[1]}"	# Root
-        [3]="${mount_Paths[2]}"	# Home
+        # [1]="${mount_Paths[0]}"	# Boot
+        # [2]="${mount_Paths[1]}"	# Root
+        # [3]="${mount_Paths[2]}"	# Home
     )
+    for curr_mount_row in "${!mount_Paths[@]}"; do
+        curr_mount="${mount_Paths[$curr_mount_row]}"
+        mount_Group[$curr_mount_row]="$curr_mount"
+    done
 
     ### Region & Location
     location=(
@@ -1406,8 +1414,12 @@ setup()
         # "
         # [Examples]
         # [1]="username,wheel,NIL,/home/profiles/username"
-        [1]="${user_ProfileInfo[0]}"
+        # [1]="${user_ProfileInfo[0]}"
     )
+    for curr_profile_row in "${!user_ProfileInfo[@]}"; do
+        curr_profile="${user_ProfileInfo[$curr_profile_row]}"
+        user_Info[$curr_profile_row]=$curr_profile
+    done
 
     ### Network Configurations
     network_config=(

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -1,17 +1,26 @@
 #!/bin/env bash
 : "
 Distro Install Script
-Modular, Portable, Customizable and Configurable script that can be modified into other distro installers
+A Modular, Portable, Customizable and Configurable script that can be modified into other distro installers
+as a template (WIP)
+
+Name is TBC, for the time being, it is 'distinstall' (horrendous name, needs change)
 =====================================
 ## Information
 + Author: Asura
 - Features: 
     + Full minimal user input install script
+    + Custom
+    + Reusable
+    + Command Line Argument support for instant running
+
 - Dependencies
     + arch-install-scripts
     + build-devel
+
 - Recommendation
     + Download the Makefile in the same directory as the script
+
 ### Background Information: 
 + A full minimal user-input, modular install script that allows user to
     change just afew variables and be able to effectively customize their system according to what they need
@@ -43,7 +52,7 @@ References:
 PROGRAM_SCRIPTNAME="installer"
 PROGRAM_NAME="ArchLinux Profile Setup Installer"
 PROGRAM_TYPE="Main"
-PROGRAM_VERSION="v1.3.2-testing"
+PROGRAM_VERSION="v1.3.4-testing"
 MODE="DEBUG" # { DEBUG | RELEASE }
 DISTRO="ArchLinux"
 cfg_name="config.sh"
@@ -219,10 +228,20 @@ boot_Partition=(
     "3;Home;primary;ext4;<x1MiB>;100%;False;NIL"
 )
 mount_Paths=(
-    # Append this and append a [n]="\${mount_Paths[<n-1>]}" in
-    "/mnt/boot"	# Boot
-    "/mnt"		# Root
-    "/mnt/home"	# Home
+	# This contains the mount paths mapped to the partition name
+	# Note:
+	#   - Please seperate all parameters with delimiter ','
+	#   - Please seperate all subvalues with delimiter ';'
+	#
+	# Syntax:
+	# [Partition Name],[mount path]
+	#
+	# Some Manadatory partition names:
+	#   - For Boot Partition : 'Boot'
+	#   - For Root Partition : 'Root'
+	"Boot,/mnt/boot"	# Boot
+	"Root,/mnt"			# Root
+	"Home,/mnt/home"	# Home
 )
 pacstrap_pkgs=(
         # EDIT: MODIFY THIS
@@ -430,7 +449,11 @@ mount_Disks()
         # Create directories if does not exists
         if [[ ! -d "$curr_dir" ]]; then
             # Directory does not exist
-            mkdir -p "$curr_dir"
+            if [[ "$MODE" == "DEBUG" ]]; then
+                echo mkdir -p "$curr_dir"
+            else
+                mkdir -p "$curr_dir"
+            fi
         fi
 
         # --- Processing

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -1,7 +1,7 @@
 #!/bin/env bash
 : "
 Distro Install Script
-A Modular, Portable, Customizable and Configurable script that can be modified into other distro installers
+A Modular, Portable, Customizable and Configurable script that can be modified into other distro installers 
 as a template (WIP)
 
 Name is TBC, for the time being, it is 'distinstall' (horrendous name, needs change)
@@ -228,34 +228,34 @@ boot_Partition=(
     "3;Home;primary;ext4;<x1MiB>;100%;False;NIL"
 )
 mount_Paths=(
-	# This contains the mount paths mapped to the partition name
-	# Note:
-	#   - Please seperate all parameters with delimiter ','
-	#   - Please seperate all subvalues with delimiter ';'
-	#
-	# Syntax:
-	# [Partition Name],[mount path]
-	#
-	# Some Manadatory partition names:
-	#   - For Boot Partition : 'Boot'
-	#   - For Root Partition : 'Root'
-	"Boot,/mnt/boot"	# Boot
-	"Root,/mnt"			# Root
-	"Home,/mnt/home"	# Home
+    # This contains the mount paths mapped to the partition name
+    # Note:
+    #   - Please seperate all parameters with delimiter ','
+    #   - Please seperate all subvalues with delimiter ';'
+    #
+    # Syntax:
+    # [Partition Name],[mount path]
+    #
+    # Some Manadatory partition names:
+    #   - For Boot Partition : 'Boot'
+    #   - For Root Partition : 'Root'
+    "Boot,/mnt/boot"	# Boot
+    "Root,/mnt"		    # Root
+    "Home,/mnt/home"	# Home
 )
 pacstrap_pkgs=(
-        # EDIT: MODIFY THIS
-        # Add the packages you want to strap in here
-        "base"
-        "linux"
-        "linux-firmware"
-        "linux-lts"
-        "linux-lts-headers"
-        "base-devel"
-        "nano"
-        "vim"
-        "networkmanager"
-        "os-prober"
+    # EDIT: MODIFY THIS
+    # Add the packages you want to strap in here
+    "base"
+    "linux"
+    "linux-firmware"
+    "linux-lts"
+    "linux-lts-headers"
+    "base-devel"
+    "nano"
+    "vim"
+    "networkmanager"
+    "os-prober"
 )
 location_Region="<your-region (Asia|US etc)>" # Refer to /usr/share/zoneinfo for your region
 location_City="<your-city (Singapore etc)>" # Refer to /usr/share/zoneinfo/<your-region> for your City
@@ -286,6 +286,36 @@ EOF
     )
     echo -e "$cfg" > $cfg_name && chmod +x $cfg_name
     echo -e "Config file template generated."
+}
+unset_arr_value()
+{
+    : "
+    Unset an array value by its position 
+
+    Returns an array using Named References
+
+    :: Parameters
+        1 : Target value to search and unset
+        2 : The array container to return to
+        3 : Your target arr to parse in
+    "
+    target_value="$1"
+    declare -n ret_val=$2
+    in_arr=("${@:3}")
+    tmp_arr=("${in_arr[@]}")
+
+    for i in ${!tmp_arr[@]}; do
+        # Get value of current index
+        curr_val="${tmp_arr[$i]}"
+ 
+        # Check if current value is the target
+        if [[ "$curr_val" == "$target_value" ]]; then
+            unset tmp_arr[$i]
+        fi
+    done
+
+    # Return array
+    ret_val=("${tmp_arr[@]}")
 }
 
 # Installation stages
@@ -438,30 +468,102 @@ mount_Disks()
 	
 	# --- Input
 	# Local Vairiables
-	device_Name="${device_Parameters["device_Name"]}"
-	device_Label="${device_Parameters["device_Label"]}"
+    device_Name="${device_Parameters["device_Name"]}"
+    device_Label="${device_Parameters["device_Label"]}"
+    partition_Name=partition_Parameters["part_Name"]
+    mount_Names=("${!mount_Group[@]}") # Temporary storage to hold the partition names for removal
 
-    # Mount all specified in the mount group
-    for i in "${!mount_Group[@]}"; do
-        # Get current directory
-        curr_dir="${mount_Group[$i]}"
+    # Get mount partition numbers
+    declare -A mount_path_Index=()
+    for path_Index in "${!mount_Paths[@]}"; do
+        # Get mount path information
+        # Column 1 = Partition Name
+        # Column 2 = Mount Path
+        path_Info="${mount_Paths[$path_Index]}"
+		curr_partition_Name="$(echo $path_Info | cut -d ',' -f1)"
+        curr_partition_Path="$(echo $path_Info | cut -d ',' -f2)"
 
-        # Create directories if does not exists
-        if [[ ! -d "$curr_dir" ]]; then
-            # Directory does not exist
+        # Increment by 1 to make it human-readable (Counter by 1)
+        counter=$((path_Index + 1))
+
+        # Assign path index number to the partition name
+        mount_path_Index[$curr_partition_Name]=$counter
+    done
+
+    # Mount root partition
+    mount_dir="${mount_Group[Root]}"
+    
+    ## Create directories if does not exists
+    if [[ ! -d "$mount_dir" ]]; then
+        ### Directory does not exist
+        if [[ "$MODE" == "DEBUG" ]]; then
+            echo mkdir -p "$mount_dir"
+        else
+            mkdir -p "$mount_dir"
+        fi
+    fi
+
+    ## --- Processing
+    ### Mount the volume to the path
+    if [[ "$MODE" == "DEBUG" ]]; then
+        echo mount "$device_Name"${mount_path_Index["Root"]} $mount_dir
+    else
+        mount "$device_Name"${mount_path_Index["Root"]} $mount_dir && \
+            echo -e "Partition [Root] Mounted." || \
+            echo -e "Error mounting Partition [Root]"
+    fi   
+
+    ### Unset/Remove Root partition from mount list
+    unset_arr_value "Root" mount_Names "${mount_Names[@]}"
+
+    # Mount boot partition
+    boot_dir="${mount_Group[Boot]}"
+
+    ## Create directories if does not exists
+    if [[ ! -d "$boot_dir" ]]; then
+        ### Directory does not exist
+        if [[ "$MODE" == "DEBUG" ]]; then
+            echo mkdir -p "$boot_dir"
+        else
+            mkdir -p "$boot_dir"
+        fi
+    fi
+
+    ## --- Processing
+    ### Mount the volume to the path
+    if [[ "$MODE" == "DEBUG" ]]; then
+        echo mount "$device_Name"${mount_path_Index["Boot"]} $boot_dir
+    else
+        mount "$device_Name"${mount_path_Index["Boot"]} $boot_dir && \
+            echo -e "Partition [Boot] Mounted." || \
+            echo -e "Error mounting Partition [Boot]"
+    fi
+
+    ### Unset/Remove Boot partition from mount list
+    unset_arr_value "Boot" mount_Names "${mount_Names[@]}"
+ 
+    # Mount all other partitions
+    for part_Names in "${mount_Names[@]}"; do
+        part_mount_dir="${mount_Group[$part_Names]}"
+
+        ## Create directories if does not exists
+        if [[ ! -d "$part_mount_dir" ]]; then
+            ### Directory does not exist
             if [[ "$MODE" == "DEBUG" ]]; then
-                echo mkdir -p "$curr_dir"
+                echo mkdir -p "$part_mount_dir"
             else
-                mkdir -p "$curr_dir"
+                mkdir -p "$part_mount_dir"
             fi
         fi
 
-        # --- Processing
-        # Mount the volume to the path
+        ## --- Processing
+        ### Mount the volume to the path
         if [[ "$MODE" == "DEBUG" ]]; then
-            echo mount "$device_Name"$i $curr_dir
+            echo mount "$device_Name"${mount_path_Index[$part_Names]} $part_mount_dir
         else
-            mount "$device_Name"$i $curr_dir
+            mount "$device_Name"${mount_path_Index[$part_Names]} $part_mount_dir && \
+                echo -e "Partition [$part_Names] Mounted." || \
+                echo -e "Error mounting Partition [$part_Names]"
         fi
     done
 }
@@ -484,8 +586,7 @@ pacstrap_Install()
 	pacstrap_Pkgs=${pkgs["pacstrap"]}
 
 	# Local Variables
-	mount_Point=${mount_Group["2"]}
-
+	mount_Point=${mount_Group["Root"]}
 
 	# --- Processing
 	if [[ "$MODE" == "DEBUG" ]]; then
@@ -507,7 +608,7 @@ fstab_Generate()
 
 	# --- Input
 	# Local Variables
-	dir_Mount="${mount_Group["2"]}"
+	dir_Mount="${mount_Group["Root"]}" # Look for root/mount partition
 
 	# Generate an fstab file (use -U or -L to define by UUID or labels, respectively):
 	if [[ "$MODE" == "DEBUG" ]]; then
@@ -527,7 +628,7 @@ arch_chroot_Exec()
 	# Local Variables
 	device_Name="${device_Parameters["device_Name"]}"
 	device_Label="${device_Parameters["device_Label"]}"
-	dir_Mount="${mount_Group["2"]}"
+	dir_Mount="${mount_Group["Root"]}"
 	region="${location["region"]}"
 	city="${location["city"]}"
 	language="${location["language"]}"
@@ -1008,7 +1109,7 @@ postinstall_sanitize()
 	# from any unnecessary files #
 	# ========================== #
 	# Local Variables
-	dir_Mount="${mount_Group["2"]}"
+	dir_Mount="${mount_Group["Root"]}"
 
 	number_of_external_scripts="${#external_scripts[@]}"
 	echo -e "External Scripts created:"
@@ -1367,19 +1468,30 @@ setup()
 
     ### Mounts
     mount_Group=(
+        # This corresponds to the configuration variable 'mount_Paths'
+        #
         # EDIT: Modify this
         # Place all your partition path 
-        #	corresponding to the partition number
+        #	corresponding to the partition name
+        #
         # [Syntax]
-        #   [partition-n]="/partition/mount/path"
-        # [1]="${mount_Paths[0]}"	# Boot
-        # [2]="${mount_Paths[1]}"	# Root
-        # [3]="${mount_Paths[2]}"	# Home
+        #   [partition-name]="/partition/mount/path"
+        #
+        # [Example]
+        #     [Boot]="${mount_Paths[0]}"	# Boot
+        #     [Root]="${mount_Paths[1]}"	# Root
+        #     [Home]="${mount_Paths[2]}"	# Home
     )
-    for curr_mount_row in "${!mount_Paths[@]}"; do
-        curr_mount="${mount_Paths[$curr_mount_row]}"
-        count=$((curr_mount_row+1))
-        mount_Group[$count]=$curr_mount
+    for i in ${!mount_Paths[@]}; do
+        # Get current mount row
+        curr_mount_row=${mount_Paths[$i]}
+
+        # Get mount directory and partition name from path definition
+        part_Name="$(echo $curr_mount_row | cut -d ',' -f1)"
+        mount_dir="$(echo $curr_mount_row | cut -d ',' -f2)"
+
+        # Set Key-Value
+        mount_Group[$part_Name]=$mount_dir
     done
 
     ### Region & Location

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -421,44 +421,26 @@ mount_Disks()
 	# Local Vairiables
 	device_Name="${device_Parameters["device_Name"]}"
 	device_Label="${device_Parameters["device_Label"]}"
-	
-	# Directories
-	dir_Boot="${mount_Group["1"]}"
-	dir_Mount="${mount_Group["2"]}"
-	dir_Home="${mount_Group["3"]}"
 
-	# --- Processing
-	# Mount the root volume to /mnt
-	if [[ "$MODE" == "DEBUG" ]]; then
-		echo mount "$device_Name"2 $dir_Mount
-	else
-		mount "$device_Name"2 $dir_Mount
-	fi
+    # Mount all specified in the mount group
+    for i in "${!mount_Group[@]}"; do
+        # Get current directory
+        curr_dir="${mount_Group[$i]}"
 
-	# Make other directories (i.e. home)
-	# Home Directory
-	if [[ "$MODE" == "DEBUG" ]]; then
-		echo mkdir -p $dir_Home
-	else
-		mkdir -p $dir_Home
-	fi
-	# Boot Directory
-	if [[ "$MODE" == "DEBUG" ]]; then
-		echo mkdir -p $dir_Boot
-	else
-		mkdir -p $dir_Boot
-	fi
+        # Create directories if does not exists
+        if [[ ! -d "$curr_dir" ]]; then
+            # Directory does not exist
+            mkdir -p "$curr_dir"
+        fi
 
-	# Mount remaining directories
-	if [[ "$MODE" == "DEBUG" ]]; then
-		echo mount "$device_Name"3 $dir_Home
-		echo mount "$device_Name"1 $dir_Boot
-	else
-		mount "$device_Name"3 $dir_Home
-		mount "$device_Name"1 $dir_Boot
-	fi
-
-	# --- Output
+        # --- Processing
+        # Mount the volume to the path
+        if [[ "$MODE" == "DEBUG" ]]; then
+            echo mount "$device_Name"$i $curr_dir
+        else
+            mount "$device_Name"$i $curr_dir
+        fi
+    done
 }
 
 pacstrap_Install()
@@ -1341,7 +1323,8 @@ setup()
     )
     for curr_partition_row in "${!boot_Partition[@]}"; do
         curr_partition="${boot_Partition[$curr_partition_row]}"
-        partition_Configuration[$curr_mount_row]="$curr_partition"
+        count=$((curr_partition_row+1))
+        partition_Configuration[$count]=$curr_partition
     done
 
     partition_Parameters=(
@@ -1372,7 +1355,8 @@ setup()
     )
     for curr_mount_row in "${!mount_Paths[@]}"; do
         curr_mount="${mount_Paths[$curr_mount_row]}"
-        mount_Group[$curr_mount_row]="$curr_mount"
+        count=$((curr_mount_row+1))
+        mount_Group[$count]=$curr_mount
     done
 
     ### Region & Location

--- a/src/base-installation/distinstall
+++ b/src/base-installation/distinstall
@@ -52,7 +52,7 @@ References:
 PROGRAM_SCRIPTNAME="installer"
 PROGRAM_NAME="ArchLinux Profile Setup Installer"
 PROGRAM_TYPE="Main"
-PROGRAM_VERSION="v1.3.4-testing"
+PROGRAM_VERSION="v1.3.5"
 MODE="DEBUG" # { DEBUG | RELEASE }
 DISTRO="ArchLinux"
 cfg_name="config.sh"


### PR DESCRIPTION
[New Features]
- Installer
    - For Developers:
        - 'partition_Configuration', 'mount_Group', 'user_Info' variables in installer now do not need to be statically modified, they will now dynamically read from the config file
            + The syntax is provided in the comments, thus if you wish to statically define, you may do so
        - Partition mounting are no longer statically defined and is now dynamic
            + This means that you can define the mount path in the config file mapped to the Partition Name
            - Note that there's a couple of requirements:
                - There are special partitions that has a special naming convention
                    + Root partition : For root partitions, you need to name it 'Root' as the mount_Disk function will mount the root partition first before mounting the others
        + New function 'unset_arr_value': To remove an element from an array via the 'unset' function

[Bug Fixes]
- Fixed bug where copying of files in postinstall_sanitize() wasnt detecting the user properly, and thus, wasnt copying to the accounts properly
- Fixed issue where user_ProfileInfo and user_Info variables needed to be manually modified by user (Inefficient)
    + because of that, 'user_Info' was only reading 1 item from the 'user_ProfileInfo' array from the config file
- Fixed issue where mounting of disk partition wasnt mounting the 'Root' partition first, thus all the mounting were out of position
    - I.E
       + Partition 'Boot' was mounted before Root => Mounting Root overwrote the boot partition => only Root and Home partitions were mounted
       + Partition 'Home' was mounted before Root => Mounting Root overwrote the home partition => Only Root and Boot partitions were mounted, and the Home directory was created inside the mount partition and mounted as the 'Home partition'

[Changes]
- configuration file
    - Modified variable 'mount_Paths'
        - Prepended a new column in each row for Partition Name, this is for identification purposes
        - Seperated by ',' delimiter
        - Thus, the current structure for the 'mount_Paths' array is 'Paritition Name,Mount Path'
        - Reason: 
            - This change was made to solve bug/issue no.1 whereby the mount paths are being mounted at inconsistent orders, which means mount directories will be overwritten.
            - This issue can be seen more clearly if you unmount and remount, the home partition will be overwritten - which suggests that the home mount directory was not mounted in the home partition

- distinstall
    - Modified global variable 'mount_Group'
        - Changes
            - Changed 'curr_mount_row' to 'curr_mount_name'
    - Created function 'unset_arr_value' to remove an element from an array via the 'unset' function using the target value's index
    - Modified function 'mount_Disks' to fix bug/issue no.1
        - Temporary Solution:
            - Root must be mounted before the Boot partition, thus the decision to add a Paritition name at the back of the mount path
            - Notes
                - There are some mandatory partition names to use
                    - Boot Partition : 'Boot'
                    - Root Partition : 'Root'
    - Fixed static user_Profile definition issue

- TODO
    - Added more tasks and ideas to the pipeline

[Created]
- Created file 'ISSUES.md' to store all issues